### PR TITLE
Allow for graceful failure of Promise.all if one of many queries reverts / errors.

### DIFF
--- a/src/ethers.ts
+++ b/src/ethers.ts
@@ -137,8 +137,18 @@ export class EthersMulticall {
           const signature = FunctionFragment.from(fragment).format();
           const callIdentifier = [contract.address, signature].join(":");
 
-          if (!res.success) throw Error(`${callIdentifier} call revert exception`);
-          if (res.returnData === "0x") throw Error(`${callIdentifier} empty return data exception`);
+          if (!res.success)
+            return {
+              error: Error(`${callIdentifier} call revert exception`),
+              address: contract.address,
+              params: params.slice(0, fragment.inputs.length),
+            };
+          if (res.returnData === "0x")
+            return {
+              error: Error(`${callIdentifier} empty return data exception`),
+              address: contract.address,
+              params: params.slice(0, fragment.inputs.length),
+            };
 
           try {
             const result = new Interface([]).decodeFunctionResult(fragment, res.returnData);

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -83,6 +83,25 @@ describe("ethers-multicall", () => {
       ]);
     });
 
+    it("should gracefully fail in a Promise.all when batching queries where one query reverts", async () => {
+      const multicall = new EthersMulticall(rpcProvider);
+      const wrappedUni = multicall.wrap(uni);
+      const wrappedUnknown = multicall.wrap(
+        new ethers.Contract("0xd6409e50c05879c5B9E091EB01E9Dd776d00A151", UniAbi, signer)
+      );
+
+      expect(Promise.all([wrappedUni.symbol(), wrappedUnknown.symbol()])).resolves.toEqual([
+        "UNI",
+        {
+          address: "0xd6409e50c05879c5B9E091EB01E9Dd776d00A151",
+          error: new Error(
+            "0xd6409e50c05879c5B9E091EB01E9Dd776d00A151:symbol() empty return data exception"
+          ),
+          params: [],
+        },
+      ]);
+    });
+
     it("should batch UNI calls without Promise.all", async () => {
       const multicall = new EthersMulticall(rpcProvider);
       const wrappedUni = multicall.wrap(uni);


### PR DESCRIPTION
feat(ethers.ts): improved wrap function handles query failures gracefully and returns error object

BREAKING CHANGE: Wrap no longer throws an error.

When calling `Promise.all([wrappedUni.symbol(), wrappedUnknown.symbol()])`, the current library will throw an error for the entire promise. Instead of throwing an error, I've made a slight modification to return an error object. The response will now come in the following form:

```
[
        "UNI",
        {
          address: "0xd6409e50c05879c5B9E091EB01E9Dd776d00A151",
          error: new Error(
            "0xd6409e50c05879c5B9E091EB01E9Dd776d00A151:symbol() empty return data exception"
          ),
          params: [],
        }
]
```

### Pull-Request Checklist
- [x] Code is up-to-date with the `main` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [N/A] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [N/A] Documentation has been updated to reflect this change
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/)
